### PR TITLE
Fix segfault when no robot detected on Linux

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+root = false
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Use 4 spaces for most files
+indent_style = space
+indent_size = 4
+max_line_length = 80
+
+[*.el]
+indent_size=2
+
+
+# Use 2 spaces for travis files
+[{package.json,*.yml}]
+indent_style = space
+indent_size = 2
+
+# Makefiles are required to use tabs
+[{makefile, Makefile}]
+indent_style = tab
+indent_size = 4

--- a/src/LinuxUtils.cpp
+++ b/src/LinuxUtils.cpp
@@ -6,7 +6,11 @@
 using namespace std;
 
 std::string LinuxUtils::FindRobot() {
-    return FindConnectedArduinos().front();
+    vector<string> arduinos = FindConnectedArduinos();
+    if (!arduinos.empty()) {
+        return arduinos.front();
+    }
+    return "";
 }
 
 std::vector<std::string> LinuxUtils::FindConnectedArduinos() {


### PR DESCRIPTION
Also `RJRobot.cpp` is using windows line endings.

Would be nice to have before https://github.com/RoboJackets/software-training/pull/55 is merged.