### PR TITLE
Added a visualization in rviz for the ground truth Aruco Markers

### DIFF
--- a/aruco_tags/aruco_tag_detection/CMakeLists.txt
+++ b/aruco_tags/aruco_tag_detection/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(image_transport REQUIRED)
+find_package(visualization_msgs REQUIRED)
 find_package(OpenCV 4 REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(stsl_interfaces REQUIRED)
@@ -31,6 +32,26 @@ install(TARGETS ${PROJECT_NAME}_component
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
+
+set(NODE_NAME aruco_tag_visual)
+add_library(${NODE_NAME}_component SHARED src/aruco_marker_visualization.cpp)
+ament_target_dependencies(${NODE_NAME}_component
+        "rclcpp"
+        "rclcpp_components"
+        "visualization_msgs"
+        "stsl_interfaces"
+        )
+rclcpp_components_register_node(
+        ${NODE_NAME}_component
+        PLUGIN "aruco_tag_detection::ArucoVisualization"
+        EXECUTABLE ${NODE_NAME}_node
+)
+
+install(TARGETS ${NODE_NAME}_component
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION lib/${NODE_NAME}
+        )
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/aruco_tags/aruco_tag_detection/package.xml
+++ b/aruco_tags/aruco_tag_detection/package.xml
@@ -16,6 +16,7 @@
   <depend>libopencv-dev</depend>
   <depend>eigen</depend>
   <depend>stsl_interfaces</depend>
+  <depend>visualization_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/aruco_tags/aruco_tag_detection/src/aruco_marker_visualization.cpp
+++ b/aruco_tags/aruco_tag_detection/src/aruco_marker_visualization.cpp
@@ -1,0 +1,84 @@
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_components/register_node_macro.hpp>
+#include <stsl_interfaces/msg/tag_array.hpp>
+#include <visualization_msgs/msg/marker.hpp>
+
+using namespace std::chrono_literals;
+
+namespace aruco_tag_detection
+{
+class ArucoVisualization : public rclcpp::Node
+{
+public:
+  ArucoVisualization(const rclcpp::NodeOptions & options)
+  : rclcpp::Node("aruco_tag_visualization", options)
+  {
+    timer_ = create_wall_timer(
+            0.1s, std::bind(&ArucoVisualization::PublishMarkers, this));
+    QueryMarkers();
+
+    marker_publisher_ = create_publisher<visualization_msgs::msg::Marker>("true_tags", 1);
+    tag_sub_ = this->create_subscription<stsl_interfaces::msg::TagArray>("/aruco_tag_detector/tags",
+               10, std::bind(&ArucoVisualization::tagCallback, this, std::placeholders::_1));
+  }
+private:
+  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr marker_publisher_;
+  rclcpp::Subscription<stsl_interfaces::msg::TagArray>::SharedPtr tag_sub_;
+  visualization_msgs::msg::Marker marker_msg_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  bool publish_ = false;
+
+  void tagCallback(const stsl_interfaces::msg::TagArray::SharedPtr tag_array_msg) {
+    publish_ = true;
+  }
+
+  void QueryMarkers() {
+    marker_msg_.header.frame_id = "/odom";
+    marker_msg_.type = visualization_msgs::msg::Marker::CUBE_LIST;
+    marker_msg_.action = visualization_msgs::msg::Marker::ADD;
+
+    marker_msg_.pose.orientation.x = 0;
+    marker_msg_.pose.orientation.y = 0;
+    marker_msg_.pose.orientation.z = -0.7071068;
+    marker_msg_.pose.orientation.w = 0.7071068;
+
+    marker_msg_.scale.x = 0.3;
+    marker_msg_.scale.y = 0.2;
+    marker_msg_.scale.z = 0.1;
+
+    marker_msg_.color.r = 1.0;
+    marker_msg_.color.b = 1.0;
+    marker_msg_.color.g = 1.0;
+
+    for(int i = 0; i < 10; i++) {
+      geometry_msgs::msg::Point point;
+      point.x = 1.0*i;
+      point.y = 0;
+      point.z = 0;
+      marker_msg_.points.push_back(point);
+    }
+  }
+
+  void PublishMarkers() {
+    if(!publish_)
+    {
+      return;
+    }
+    marker_msg_.header.stamp = this->now();
+
+    marker_publisher_->publish(marker_msg_);
+    publish_ = false;
+  }
+};
+}  // namespace aruco_tag_detection
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::NodeOptions options;
+  rclcpp::spin(std::make_shared<aruco_tag_detection::ArucoVisualization>(options));
+  rclcpp::shutdown();
+  return 0;
+}
+
+RCLCPP_COMPONENTS_REGISTER_NODE(aruco_tag_detection::ArucoVisualization)

--- a/aruco_tags/aruco_tag_detection/src/aruco_marker_visualization.cpp
+++ b/aruco_tags/aruco_tag_detection/src/aruco_marker_visualization.cpp
@@ -2,6 +2,7 @@
 #include <rclcpp_components/register_node_macro.hpp>
 #include <stsl_interfaces/msg/tag_array.hpp>
 #include <visualization_msgs/msg/marker.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 using namespace std::chrono_literals;
 
@@ -14,17 +15,17 @@ public:
   : rclcpp::Node("aruco_tag_visualization", options)
   {
     timer_ = create_wall_timer(
-            0.1s, std::bind(&ArucoVisualization::PublishMarkers, this));
+            1.0s, std::bind(&ArucoVisualization::PublishMarkers, this));
     QueryMarkers();
 
-    marker_publisher_ = create_publisher<visualization_msgs::msg::Marker>("true_tags", 1);
+    marker_publisher_ = create_publisher<visualization_msgs::msg::MarkerArray>("true_tags", 1);
     tag_sub_ = this->create_subscription<stsl_interfaces::msg::TagArray>("/aruco_tag_detector/tags",
                10, std::bind(&ArucoVisualization::tagCallback, this, std::placeholders::_1));
   }
 private:
-  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr marker_publisher_;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_publisher_;
   rclcpp::Subscription<stsl_interfaces::msg::TagArray>::SharedPtr tag_sub_;
-  visualization_msgs::msg::Marker marker_msg_;
+  visualization_msgs::msg::MarkerArray marker_array_msg_;
   rclcpp::TimerBase::SharedPtr timer_;
   bool publish_ = false;
 
@@ -33,30 +34,56 @@ private:
   }
 
   void QueryMarkers() {
-    marker_msg_.header.frame_id = "/odom";
-    marker_msg_.type = visualization_msgs::msg::Marker::CUBE_LIST;
-    marker_msg_.action = visualization_msgs::msg::Marker::ADD;
 
-    marker_msg_.pose.orientation.x = 0;
-    marker_msg_.pose.orientation.y = 0;
-    marker_msg_.pose.orientation.z = -0.7071068;
-    marker_msg_.pose.orientation.w = 0.7071068;
+    for(int i = 0; i < 2; i++) {
+      visualization_msgs::msg::Marker marker_msg;
+      marker_msg.id = i;
+      marker_msg.header.frame_id = "/odom";
+      marker_msg.type = visualization_msgs::msg::Marker::CUBE_LIST;
+      marker_msg.action = visualization_msgs::msg::Marker::ADD;
 
-    marker_msg_.scale.x = 0.3;
-    marker_msg_.scale.y = 0.2;
-    marker_msg_.scale.z = 0.1;
+      marker_msg.pose.orientation.x = 0.0;
+      marker_msg.pose.orientation.y = 0.0;
+      marker_msg.pose.orientation.z = 0.0;
+      marker_msg.pose.orientation.w = 1.0;
 
-    marker_msg_.color.r = 1.0;
-    marker_msg_.color.b = 1.0;
-    marker_msg_.color.g = 1.0;
+      marker_msg.color.a = 0.5;
+      marker_msg.color.r = 0.0;
+      marker_msg.color.b = 0.0;
+      marker_msg.color.g = 1.0;
 
-    for(int i = 0; i < 10; i++) {
-      geometry_msgs::msg::Point point;
-      point.x = 1.0*i;
-      point.y = 0;
-      point.z = 0;
-      marker_msg_.points.push_back(point);
+      marker_array_msg_.markers.push_back(marker_msg);
     }
+
+    marker_array_msg_.markers[0].scale.x = 0.025;
+    marker_array_msg_.markers[0].scale.y = 0.2;
+    marker_array_msg_.markers[0].scale.z = 0.2;
+
+    marker_array_msg_.markers[0].points.resize(2);
+    marker_array_msg_.markers[0].points[0].x = 0.6096;
+    marker_array_msg_.markers[0].points[0].y = 0;
+    marker_array_msg_.markers[0].points[0].z = 0.05;
+    marker_array_msg_.markers[0].points[1].x = -0.6096;
+    marker_array_msg_.markers[0].points[1].y = 0;
+    marker_array_msg_.markers[0].points[1].z = 0.05;
+
+    marker_array_msg_.markers[1].scale.x = 0.2;
+    marker_array_msg_.markers[1].scale.y = 0.025;
+    marker_array_msg_.markers[1].scale.z = 0.2;
+
+    marker_array_msg_.markers[1].points.resize(4);
+    marker_array_msg_.markers[1].points[0].x = -0.3;
+    marker_array_msg_.markers[1].points[0].y = -0.381;
+    marker_array_msg_.markers[1].points[0].z = 0.05;
+    marker_array_msg_.markers[1].points[1].x = 0.3;
+    marker_array_msg_.markers[1].points[1].y = -0.381;
+    marker_array_msg_.markers[1].points[1].z = 0.05;
+    marker_array_msg_.markers[1].points[2].x = -0.3;
+    marker_array_msg_.markers[1].points[2].y = 0.381;
+    marker_array_msg_.markers[1].points[2].z = 0.05;
+    marker_array_msg_.markers[1].points[3].x = 0.3;
+    marker_array_msg_.markers[1].points[3].y = 0.381;
+    marker_array_msg_.markers[1].points[3].z = 0.05;
   }
 
   void PublishMarkers() {
@@ -64,21 +91,16 @@ private:
     {
       return;
     }
-    marker_msg_.header.stamp = this->now();
+    for(int i = 0; i < marker_array_msg_.markers.size(); i++) {
+      marker_array_msg_.markers[i].header.stamp = this->now();
+      marker_array_msg_.markers[i].action = 0;
+      marker_array_msg_.markers[i].lifetime = rclcpp::Duration(1.0s);
+    }
 
-    marker_publisher_->publish(marker_msg_);
+    marker_publisher_->publish(marker_array_msg_);
     publish_ = false;
   }
 };
 }  // namespace aruco_tag_detection
-
-int main(int argc, char * argv[])
-{
-  rclcpp::init(argc, argv);
-  rclcpp::NodeOptions options;
-  rclcpp::spin(std::make_shared<aruco_tag_detection::ArucoVisualization>(options));
-  rclcpp::shutdown();
-  return 0;
-}
 
 RCLCPP_COMPONENTS_REGISTER_NODE(aruco_tag_detection::ArucoVisualization)

--- a/aruco_tags/aruco_tag_detection/src/aruco_marker_visualization.cpp
+++ b/aruco_tags/aruco_tag_detection/src/aruco_marker_visualization.cpp
@@ -32,7 +32,8 @@ private:
       marker_msg.header = tag_array_msg->header;
       marker_msg.type = visualization_msgs::msg::Marker::CUBE;
       marker_msg.action = visualization_msgs::msg::Marker::ADD;
-      marker_msg.lifetime = rclcpp::Duration(1.0s);
+      marker_msg.ns = "/tag_visualization";
+      marker_msg.lifetime = rclcpp::Duration(0.15s);
 
       marker_msg.pose.position.x = tag.pose.position.x;
       marker_msg.pose.position.y = tag.pose.position.y;

--- a/aruco_tags/aruco_tag_detection/src/aruco_marker_visualization.cpp
+++ b/aruco_tags/aruco_tag_detection/src/aruco_marker_visualization.cpp
@@ -1,3 +1,23 @@
+// Copyright 2021 RoboJackets
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <stsl_interfaces/msg/tag_array.hpp>

--- a/aruco_tags/aruco_tag_detection/src/aruco_marker_visualization.cpp
+++ b/aruco_tags/aruco_tag_detection/src/aruco_marker_visualization.cpp
@@ -15,18 +15,20 @@ public:
   : rclcpp::Node("aruco_tag_visualization", options)
   {
     marker_pub_ = create_publisher<visualization_msgs::msg::MarkerArray>("true_tags", 1);
-    tag_sub_ = this->create_subscription<stsl_interfaces::msg::TagArray>("/aruco_tag_detector/tags",
-               10, std::bind(&ArucoVisualization::tagCallback, this, std::placeholders::_1));
+    tag_sub_ = this->create_subscription<stsl_interfaces::msg::TagArray>(
+      "/aruco_tag_detector/tags",
+      10, std::bind(&ArucoVisualization::tagCallback, this, std::placeholders::_1));
   }
+
 private:
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_pub_;
   rclcpp::Subscription<stsl_interfaces::msg::TagArray>::SharedPtr tag_sub_;
 
-  void tagCallback(const stsl_interfaces::msg::TagArray::SharedPtr tag_array_msg) {
+  void tagCallback(const stsl_interfaces::msg::TagArray::SharedPtr tag_array_msg)
+  {
     visualization_msgs::msg::MarkerArray marker_array_msg;
 
-    for(const stsl_interfaces::msg::Tag & tag : tag_array_msg->tags)
-    {
+    for (const stsl_interfaces::msg::Tag & tag : tag_array_msg->tags) {
       visualization_msgs::msg::Marker marker_msg;
       marker_msg.id = tag.id;
       marker_msg.header = tag_array_msg->header;

--- a/traini_bringup/launch/tag_detector.launch.py
+++ b/traini_bringup/launch/tag_detector.launch.py
@@ -31,5 +31,10 @@ def generate_launch_description():
             parameters=[
                 {'tag_size': 0.1}
             ]
+        ),
+        Node(
+            package='aruco_tag_detection',
+            executable='aruco_tag_visual_node',
+            output='screen'
         )
     ])

--- a/traini_bringup/launch/tag_detector.launch.py
+++ b/traini_bringup/launch/tag_detector.launch.py
@@ -19,6 +19,7 @@
 # THE SOFTWARE.
 
 from launch import LaunchDescription
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -29,12 +30,16 @@ def generate_launch_description():
             executable='aruco_tag_detection_node',
             output='screen',
             parameters=[
+                {'use_sim_time': LaunchConfiguration('use_sim_time', default='false')},
                 {'tag_size': 0.1}
             ]
         ),
         Node(
             package='aruco_tag_detection',
             executable='aruco_tag_visual_node',
-            output='screen'
+            output='screen',
+            parameters=[
+                {'use_sim_time': LaunchConfiguration('use_sim_time', default='false')},
+            ]
         )
     ])


### PR DESCRIPTION
This PR...

- adds a new node in the aruco_tag_detection package that creates a visualization message for the ground truth aruco messages
- It uses hard coded positions to create a cube_list at the correct locations. A cube list was used since it can be rendered in one batch rather than sequentially. The student side in the transform node will be using the regular rectangle since this requires them to have identical orientations. 
- This only publishes markers when the detection code is returning detection messages.
- The ground truth ones have transparency so the student code can publish markers that align with the ground truth ones.

![2021-07-05-115507_3840x2160_scrot](https://user-images.githubusercontent.com/13954395/124497432-d6903d80-dd88-11eb-878d-c8d69363c9e6.png)
