### PR TITLE
Week1 updates

### DIFF
--- a/traini_bringup/config/joystick_params_playstation.yaml
+++ b/traini_bringup/config/joystick_params_playstation.yaml
@@ -1,0 +1,14 @@
+joy_node:
+  ros__parameters:
+    deadzone: 0.001
+teleop_twist_joy_node:
+  ros__parameters:
+    require_enable_button: false
+    axis_linear:
+      x: 1
+    axis_angular:
+      yaw: 2
+    scale_linear:
+      x: 0.25
+    scale_angular:
+      yaw: 2.0

--- a/traini_bringup/config/joystick_params_xbox.yaml
+++ b/traini_bringup/config/joystick_params_xbox.yaml
@@ -8,6 +8,7 @@ teleop_twist_joy_node:
       x: 1
     axis_angular:
       yaw: 3
+    scale_linear:
+      x: 0.25
     scale_angular:
-      yaw: 4.0
-    
+      yaw: 2.0

--- a/traini_bringup/launch/joystick_control.launch.py
+++ b/traini_bringup/launch/joystick_control.launch.py
@@ -39,7 +39,7 @@ from ament_index_python.packages import get_package_share_directory
 
 def generate_launch_description():
     default_parameters_file_path = os.path.join(get_package_share_directory(
-        'traini_bringup'), 'config', 'joystick_parameters.yaml')
+        'traini_bringup'), 'config', 'joystick_params_playstation.yaml')
 
     return LaunchDescription([
         DeclareLaunchArgument(

--- a/traini_gazebo/worlds/training_world.sdf
+++ b/traini_gazebo/worlds/training_world.sdf
@@ -3,9 +3,19 @@
     <world name="training_world">
         <gravity>0 0 0</gravity>
 
-        <include>
-            <uri>model://sun</uri>
-        </include>
+        <light type="directional" name="sun">
+            <cast_shadows>true</cast_shadows>
+            <pose>0 0 10 0 0 0</pose>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+            <attenuation>
+                <range>1000</range>
+                <constant>0.9</constant>
+                <linear>0.01</linear>
+                <quadratic>0.001</quadratic>
+            </attenuation>
+            <direction>-0.5 0.1 -0.9</direction>
+        </light>
 
         <include>
             <uri>model://floor_mat</uri>


### PR DESCRIPTION
Two last minute updates from testing the VM

- Removes dependency on external "sun" gazebo model, because the VM was having trouble finding it. Replaced by just adding the light manually to the world file.
- Adds a second joystick config file to support the playstation-style cheap Amazon gamepad.