### PR TITLE
Adds noisy odometry Gazebo plugin.

### DIFF
--- a/stsl_gazebo_plugins/CMakeLists.txt
+++ b/stsl_gazebo_plugins/CMakeLists.txt
@@ -6,6 +6,8 @@ find_package(rclcpp REQUIRED)
 find_package(gazebo_dev REQUIRED)
 find_package(gazebo_ros REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
 
 find_library(
   LED_PLUGIN_LIBRARY
@@ -22,8 +24,18 @@ ament_target_dependencies(RosLightControlPlugin
 )
 target_link_libraries(RosLightControlPlugin ${LED_PLUGIN_LIBRARY})
 
+add_library(RosNoisyPlanarOdomPlugin SHARED src/RosNoisyPlanarOdomPlugin.cpp)
+ament_target_dependencies(RosNoisyPlanarOdomPlugin
+  "gazebo_dev"
+  "gazebo_ros"
+  "rclcpp"
+  "std_msgs"
+  "geometry_msgs"
+  "nav_msgs"
+)
+
 install(
-  TARGETS RosLightControlPlugin
+  TARGETS RosLightControlPlugin RosNoisyPlanarOdomPlugin
   DESTINATION lib
 )
 

--- a/stsl_gazebo_plugins/package.xml
+++ b/stsl_gazebo_plugins/package.xml
@@ -13,6 +13,8 @@
   <depend>gazebo_dev</depend>
   <depend>gazebo_ros</depend>
   <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/stsl_gazebo_plugins/src/RosNoisyPlanarOdomPlugin.cpp
+++ b/stsl_gazebo_plugins/src/RosNoisyPlanarOdomPlugin.cpp
@@ -73,7 +73,6 @@ public:
     tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(ros_node_);
 
     prev_update_time_ = world_->SimTime();
-    odom_pose_ = parent_->WorldPose();
 
     update_connection_ =
       gazebo::event::Events::ConnectWorldUpdateBegin(

--- a/stsl_gazebo_plugins/src/RosNoisyPlanarOdomPlugin.cpp
+++ b/stsl_gazebo_plugins/src/RosNoisyPlanarOdomPlugin.cpp
@@ -1,0 +1,206 @@
+// Copyright 2021 RoboJackets
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gazebo/gazebo.hh>
+#include <gazebo/transport/transport.hh>
+#include <gazebo/physics/Model.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo_ros/conversions/builtin_interfaces.hpp>
+#include <gazebo_ros/conversions/geometry_msgs.hpp>
+#include <gazebo_ros/node.hpp>
+#include <ignition/math/Vector3.hh>
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <memory>
+#include <random>
+#include <string>
+
+namespace stsl_gazebo_plugins
+{
+
+class RosNoisyPlanarOdomPlugin : public gazebo::ModelPlugin
+{
+public:
+  void Load(gazebo::physics::ModelPtr parent, sdf::ElementPtr sdf) override
+  {
+    parent_ = parent;
+    world_ = parent->GetWorld();
+
+    odom_frame_ = sdf->Get<std::string>("odometry_frame", "odom").first;
+    robot_frame_ = sdf->Get<std::string>("robot_base_frame", "base_footprint").first;
+
+    const auto publish_rate = sdf->Get<double>("publish_rate", 20.0).first;
+    publish_period_sec_ = publish_rate > 0.0 ? 1.0 / publish_rate : 0.0;
+    prev_publish_time_ = world_->SimTime();
+
+    const auto vel_noise_std_dev = sdf->Get<double>("velocity_noise_std_dev", 0.25).first;
+    random_engine_ = std::default_random_engine(std::random_device{} ());
+    noise_distribution_ = std::normal_distribution<double>(0.0, vel_noise_std_dev);
+
+    pub_covariance_x_ = sdf->Get<double>("covariance_x", 1e-4).first;
+    pub_covariance_y_ = sdf->Get<double>("covariance_y", 1e-4).first;
+    pub_covariance_yaw_ = sdf->Get<double>("covariance_yaw", 1e-2).first;
+
+    gazebo_node_ = boost::make_shared<gazebo::transport::Node>();
+    gazebo_node_->Init();
+
+    ros_node_ = gazebo_ros::Node::Get(sdf);
+
+    odom_pub_ = ros_node_->create_publisher<nav_msgs::msg::Odometry>(
+      "~/odom",
+      rclcpp::SystemDefaultsQoS());
+
+    tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(ros_node_);
+
+    prev_update_time_ = world_->SimTime();
+    odom_pose_ = parent_->WorldPose();
+
+    update_connection_ =
+      gazebo::event::Events::ConnectWorldUpdateBegin(
+      std::bind(
+        &RosNoisyPlanarOdomPlugin::OnUpdate, this,
+        std::placeholders::_1));
+  }
+
+  void Reset() override
+  {
+    prev_update_time_ = world_->SimTime();
+    odom_pose_ = parent_->WorldPose();
+    prev_odom_pose_.Reset();
+    odom_linear_vel_ = ignition::math::Vector3d::Zero;
+    odom_angular_vel_ = ignition::math::Vector3d::Zero;
+  }
+
+private:
+  gazebo::event::ConnectionPtr update_connection_;
+  gazebo::transport::NodePtr gazebo_node_;
+  gazebo::physics::WorldPtr world_;
+  gazebo::physics::ModelPtr parent_;
+
+  gazebo_ros::Node::SharedPtr ros_node_;
+
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
+  std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+
+  std::default_random_engine random_engine_;
+  std::normal_distribution<double> noise_distribution_;
+
+  ignition::math::Pose3d odom_pose_;
+  ignition::math::Pose3d prev_odom_pose_;
+  ignition::math::Vector3d odom_linear_vel_;
+  ignition::math::Vector3d odom_angular_vel_;
+
+  gazebo::common::Time prev_update_time_;
+
+  double publish_period_sec_{10.0};
+  gazebo::common::Time prev_publish_time_;
+
+  std::string odom_frame_;
+  std::string robot_frame_;
+
+  double pub_covariance_x_;
+  double pub_covariance_y_;
+  double pub_covariance_yaw_;
+
+  const double low_velocity_threshold_{1e-4};
+
+  void OnUpdate(const gazebo::common::UpdateInfo & info)
+  {
+    UpdateOdometry(info.simTime);
+
+    if ( (info.simTime - prev_publish_time_).Double() >= publish_period_sec_) {
+      prev_publish_time_ = info.simTime;
+      PublishOdometry(info.simTime);
+      BroadcastTF(info.simTime);
+    }
+  }
+
+  void UpdateOdometry(const gazebo::common::Time & current_time)
+  {
+    prev_odom_pose_ = odom_pose_;
+
+    const auto delta_time = (current_time - prev_update_time_).Double();
+    prev_update_time_ = current_time;
+
+    const auto & world_pose = parent_->WorldPose();
+
+    auto relative_linear_vel = parent_->RelativeLinearVel();
+    if (std::abs(relative_linear_vel.X()) > low_velocity_threshold_) {
+      relative_linear_vel.X() += noise_distribution_(random_engine_);
+    }
+    if (std::abs(relative_linear_vel.Y()) > low_velocity_threshold_) {
+      relative_linear_vel.Y() += noise_distribution_(random_engine_);
+    }
+
+    auto relative_angular_vel = parent_->RelativeAngularVel();
+    if (std::abs(relative_angular_vel.Z()) > low_velocity_threshold_) {
+      relative_angular_vel.Z() += noise_distribution_(random_engine_);
+    }
+
+    const auto rot_inv = world_pose.Rot().Inverse();
+    odom_linear_vel_ = world_pose.Rot() * relative_linear_vel;
+    odom_angular_vel_ = relative_angular_vel;
+
+    odom_pose_.Pos() += odom_linear_vel_ * delta_time;
+
+    odom_pose_.Rot() *= ignition::math::Quaternion(odom_angular_vel_ * delta_time);
+  }
+
+  void BroadcastTF(const gazebo::common::Time & current_time)
+  {
+    geometry_msgs::msg::TransformStamped msg;
+    msg.header.stamp = gazebo_ros::Convert<builtin_interfaces::msg::Time>(current_time);
+    msg.header.frame_id = odom_frame_;
+    msg.child_frame_id = robot_frame_;
+    msg.transform = gazebo_ros::Convert<geometry_msgs::msg::Transform>(odom_pose_);
+    tf_broadcaster_->sendTransform(msg);
+  }
+
+  void PublishOdometry(const gazebo::common::Time & current_time)
+  {
+    nav_msgs::msg::Odometry msg;
+    msg.header.stamp = gazebo_ros::Convert<builtin_interfaces::msg::Time>(current_time);
+    msg.header.frame_id = odom_frame_;
+    msg.child_frame_id = robot_frame_;
+    msg.pose.pose = gazebo_ros::Convert<geometry_msgs::msg::Pose>(odom_pose_);
+    msg.pose.covariance[0] = pub_covariance_x_;
+    msg.pose.covariance[7] = pub_covariance_y_;
+    msg.pose.covariance[14] = 1e12;
+    msg.pose.covariance[21] = 1e12;
+    msg.pose.covariance[28] = 1e12;
+    msg.pose.covariance[35] = pub_covariance_yaw_;
+    msg.twist.twist.linear = gazebo_ros::Convert<geometry_msgs::msg::Vector3>(odom_linear_vel_);
+    msg.twist.twist.angular = gazebo_ros::Convert<geometry_msgs::msg::Vector3>(odom_angular_vel_);
+    msg.twist.covariance[0] = pub_covariance_x_;
+    msg.twist.covariance[7] = pub_covariance_y_;
+    msg.twist.covariance[14] = 1e12;
+    msg.twist.covariance[21] = 1e12;
+    msg.twist.covariance[28] = 1e12;
+    msg.twist.covariance[35] = pub_covariance_yaw_;
+    odom_pub_->publish(msg);
+  }
+};
+
+GZ_REGISTER_MODEL_PLUGIN(RosNoisyPlanarOdomPlugin)
+
+}  // namespace stsl_gazebo_plugins

--- a/traini_gazebo/CMakeLists.txt
+++ b/traini_gazebo/CMakeLists.txt
@@ -13,8 +13,11 @@ generate_aruco_tag_models(
 )
 
 install(
-  PROGRAMS scripts/kill_gazebo_server.sh
-  DESTINATION bin
+  PROGRAMS 
+  scripts/kill_gazebo_server.sh
+  scripts/publish_map_boundary.py
+  scripts/randomize_robot_pose.py
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 install(

--- a/traini_gazebo/models/traini/model.sdf
+++ b/traini_gazebo/models/traini/model.sdf
@@ -28,6 +28,8 @@
             <odometry_frame>odom</odometry_frame>
             <robot_base_frame>base_footprint</robot_base_frame>
 
+            <velocity_noise_std_dev>0.25</velocity_noise_std_dev>
+
             <covariance_x>0.0001</covariance_x>
             <covariance_y>0.0001</covariance_y>
             <covariance_yaw>0.01</covariance_yaw>

--- a/traini_gazebo/models/traini/model.sdf
+++ b/traini_gazebo/models/traini/model.sdf
@@ -5,6 +5,23 @@
             <update_rate>100</update_rate>
             <publish_rate>10</publish_rate>
 
+            <publish_odom>false</publish_odom>
+            <publish_odom_tf>false</publish_odom_tf>
+
+            <odometry_frame>odom</odometry_frame>
+            <robot_base_frame>base_footprint</robot_base_frame>
+
+            <covariance_x>0.0001</covariance_x>
+            <covariance_y>0.0001</covariance_y>
+            <covariance_yaw>0.01</covariance_yaw>
+        </plugin>
+
+        <plugin name='noisy_odom' filename='libRosNoisyPlanarOdomPlugin.so'>
+            <ros>
+                <remapping>/noisy_odom/odom:=/odom</remapping>
+            </ros>
+            <publish_rate>10</publish_rate>
+
             <publish_odom>true</publish_odom>
             <publish_odom_tf>true</publish_odom_tf>
 

--- a/traini_gazebo/scripts/publish_map_boundary.py
+++ b/traini_gazebo/scripts/publish_map_boundary.py
@@ -1,0 +1,39 @@
+#! /usr/bin/python3
+
+import rclpy
+from rclpy.qos import QoSProfile, DurabilityPolicy, qos_profile_system_default
+from rclpy.node import Node
+from geometry_msgs.msg import PolygonStamped
+from geometry_msgs.msg import Point32
+
+class BoundaryPublisher(Node):
+  def __init__(self):
+    super().__init__('boundary_publisher')
+    qos = qos_profile_system_default
+    qos.durability = DurabilityPolicy.TRANSIENT_LOCAL
+    self.publisher = self.create_publisher(PolygonStamped, '/map_boundary', qos)
+    self.publish_boundary()
+  
+  def publish_boundary(self):
+    msg = PolygonStamped()
+    msg.header.frame_id = 'map'
+    msg.header.stamp = self.get_clock().now().to_msg()
+    map_width = 1.2192
+    map_height = 0.762
+    msg.polygon.points = [
+      Point32(x=map_width/2, y=map_height/2),
+      Point32(x=map_width/2, y=-map_height/2),
+      Point32(x=-map_width/2, y=-map_height/2),
+      Point32(x=-map_width/2, y=map_height/2)
+    ]
+    self.publisher.publish(msg)
+
+def main(args=None):
+  rclpy.init(args=args)
+  node = BoundaryPublisher()
+  rclpy.spin(node)
+  node.destroy_node()
+  rclpy.shutdown()
+
+if __name__ == '__main__':
+  main()

--- a/traini_gazebo/scripts/randomize_robot_pose.py
+++ b/traini_gazebo/scripts/randomize_robot_pose.py
@@ -1,0 +1,59 @@
+#! /usr/bin/python3
+
+import random
+import rclpy
+from rclpy.node import Node
+from gazebo_msgs.srv import SetEntityState
+
+
+class RandomizeRobotPoseNode(Node):
+
+    def __init__(self):
+        super().__init__('randomize_robot_pose')
+        self.client = self.create_client(
+            SetEntityState, '/gazebo/set_entity_state')
+        while not self.client.wait_for_service(timeout_sec=1.0):
+            self.get_logger().info('service not available, waiting again...')
+        self.request = SetEntityState.Request()
+
+    def send_request(self):
+        self.request.state.name = 'Traini'
+        self.request.state.pose.position.x = random.uniform(-0.3, 0.3)
+        self.request.state.pose.position.y = random.uniform(-0.15, 0.15)
+        self.future = self.client.call_async(self.request)
+
+    def check_response(self):
+        if self.future.done():
+            try:
+                response = self.future.result()
+            except Exception as e:
+                self.get_logger().error(f'Service call failed {e}')
+                return True
+            else:
+                if response:
+                    self.get_logger().info('Done!')
+                    return True
+                else:
+                    self.get_logger().info("Simulator couldn't move the robot!")
+                    return True
+        else:
+            return False
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    node = RandomizeRobotPoseNode()
+    node.send_request()
+
+    while rclpy.ok():
+        rclpy.spin_once(node)
+        if node.check_response():
+            break
+
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/traini_gazebo/worlds/training_world.sdf
+++ b/traini_gazebo/worlds/training_world.sdf
@@ -3,6 +3,12 @@
     <world name="training_world">
         <gravity>0 0 0</gravity>
 
+        <plugin name='gazebo_ros_state' filename='libgazebo_ros_state.so'>
+            <ros>
+                <namespace>gazebo</namespace>
+            </ros>
+        </plugin>
+
         <light type="directional" name="sun">
             <cast_shadows>true</cast_shadows>
             <pose>0 0 10 0 0 0</pose>


### PR DESCRIPTION
This PR adds a new Gazebo plugin that applies gaussian noise to the simulated robot's velocity and publishes odometry data based on this noisy velocity.

The standard planar move plugin has had its odom publishing disabled so it won't conflict with the noisy one.